### PR TITLE
brake fix. Smarter use of brake

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -45,7 +45,7 @@ class Controller(object):
 
         vel_error = target_vel - cur_vel
         velocity = self.pid_velocity.step(vel_error, time_elapsed)
-        if (velocity < 0.002):
+        if (velocity < 0.005) and (velocity > -0.005):
             velocity = 0.0
         velocity = self.lowpass_velocity.filt(velocity)
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -45,6 +45,7 @@ class WaypointUpdater(object):
 
         rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+        self.is_signal_red_pub = rospy.Publisher('is_signal_red', Bool, queue_size=1)
 
         self.publish()
 
@@ -80,6 +81,8 @@ class WaypointUpdater(object):
                 final_waypoints_msg.header.stamp = rospy.Time(0)
                 final_waypoints_msg.waypoints = next_waypoints
                 self.final_waypoints_pub.publish(final_waypoints_msg)
+
+                self.is_signal_red_pub.publish(self.is_signal_red)
 
             rate.sleep()
 


### PR DESCRIPTION
Bugfix: Brake engages again

Tweak: Smarter use of brake
- When stopped at red light and not moving much, brake fully engages and stays locked until light turns green again.
- Vehicle does not engage brake unless necessary to stop at a red light. If it exceeds speed limit slightly, it just lifts off the gas to bleed off velocity.