### PR TITLE
dbw_enabled treatment; circular track fixes

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -87,6 +87,8 @@ class DBWNode(object):
                   if DEBUG:
                     rospy.logerr('throttle: {}, brake: {}'.format(throttle, brake))
                   self.publish(throttle, brake, steer)
+                else:
+                  self.controller.pid_reset()
             rate.sleep()
 
     def publish(self, throttle, brake, steer):

--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -19,3 +19,7 @@ class LowPassFilter(object):
 
         self.last_val = val
         return val
+
+    def reset(self):
+        self.last_val = 0.
+        self.ready = False

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -16,6 +16,7 @@ class PID(object):
     def reset(self):
         self.int_val = 0.0
         self.last_int_val = 0.0
+        self.last_error = 0.0
 
     def step(self, error, sample_time):
         self.last_int_val = self.int_val

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -62,3 +62,9 @@ class Controller(object):
 
         # Return throttle, brake, steer
         return throttle, brake, steer
+
+    def pid_reset(self):
+        self.pid_velocity.reset()
+        self.pid_steering.reset()
+        self.lowpass_steering.reset()
+        self.lowpass_velocity.reset()


### PR DESCRIPTION
- should now work w/ circular track (waypoint indeces going through zero)
- reduced lookahead to 50 since real track will only have about 60 waypoints
- pid ctrl and lowpass filters reset if manual override is active
- stopping at traffic lights now dependent on amount of waypoints to go until red light